### PR TITLE
[DOW-36] Verify if list exists on active list check

### DIFF
--- a/admin/partials/doppler-for-learnpress-admin-display.php
+++ b/admin/partials/doppler-for-learnpress-admin-display.php
@@ -43,7 +43,9 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
     
     $lists = $this->get_alpha_lists();
     $subscribers_lists = get_option('dplr_learnpress_subscribers_list');
-    $this->check_active_list($subscribers_lists ? $subscribers_lists['buyers'] : '',$lists);
+    $this->check_active_list($subscribers_lists && isset($subscribers_lists['buyers']) 
+        ? $subscribers_lists['buyers'] 
+        : '',$lists);
 
     require_once('settings.php');
 


### PR DESCRIPTION
When you first get into the plugins it throws a warning when you don't have any list selected to sincronize.